### PR TITLE
Updated to bat 0.11.0 + rewrote Dockerfile using Alpine as a base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
-FROM ubuntu:16.04
+FROM alpine:3.9
 
 MAINTAINER Dan Lynn <docker@danlynn.org>
 
 WORKDIR /myapp
 
-RUN \
-    apt-get update &&\
-    apt-get install -y curl less git
+ARG BAT_VERSION="0.11.0"
 
-RUN \
-    curl -L https://github.com/sharkdp/bat/releases/download/v0.10.0/bat-v0.10.0-x86_64-unknown-linux-gnu.tar.gz | tar -C /usr/local/src -zxf - &&\
-    ln -s /usr/local/src/bat-v0.10.0-x86_64-unknown-linux-gnu/bat /usr/local/bin/bat
+RUN apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing --no-cache \
+      # required for window size detection
+      bash \
+      # `bat`s default pager
+      less \
+      bat="${BAT_VERSION}-r0" && \
 
-# configure bash to check window size after each command
-RUN \
+    # configure bash to check the window size after each command
     echo "shopt -s checkwinsize" >> ~/.bashrc
 
-# execute `bat` after a slight pause in order to give
-# the tty time to realize the current window size
+# execute `bat` after a pause so that tty can detect the current window size
 ENTRYPOINT [ "bash", "-c", "sleep 0.1; bat $0 $@" ]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ See the __*excellent*__ `bat` project that this docker container wraps at [https
 
 ### Supported tags and respective `Dockerfile` links
 
-+ [`0.10.0`,`latest` (0.10.0/Dockerfile)](https://github.com/danlynn/bat/blob/0.10.0/Dockerfile)
++ [`0.11.0`,`latest` (0.11.0/Dockerfile)](https://github.com/danlynn/bat/blob/0.11.0/Dockerfile)
++ [`0.10.0` (0.10.0/Dockerfile)](https://github.com/danlynn/bat/blob/0.10.0/Dockerfile)
 + [`0.9.0` (0.9.0/Dockerfile)](https://github.com/danlynn/bat/blob/0.9.0/Dockerfile)
 + [`0.7.1` (0.7.1/Dockerfile)](https://github.com/danlynn/bat/blob/0.7.1/Dockerfile)
 + [`0.6.1` (0.6.1/Dockerfile)](https://github.com/danlynn/bat/blob/0.6.1/Dockerfile)


### PR DESCRIPTION
- bumped `bat`'s version to `0.11.0` (latest) & updated README
- rewrote Dockerfile to use Alpine 3.9 as a base, lowering uncompressed
  image size to ~14.4MB from ~238MB using Ubuntu 16.04